### PR TITLE
Add inactivity dim/sleep and USB-gated logging

### DIFF
--- a/include/activity_monitor.h
+++ b/include/activity_monitor.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <Arduino.h>
+
+void activity_monitor_init(uint32_t user_timeout_ms, uint32_t machine_timeout_ms);
+void activity_monitor_mark_user_activity();
+void activity_monitor_mark_machine_activity();
+bool activity_monitor_is_user_inactive(uint32_t now_ms);
+bool activity_monitor_is_machine_inactive(uint32_t now_ms);
+unsigned long activity_monitor_last_user_ms();
+unsigned long activity_monitor_last_machine_ms();

--- a/include/config.h
+++ b/include/config.h
@@ -18,6 +18,13 @@ static constexpr const char *NTP_SERVER = "pool.ntp.org";
 #define  BATTERY_VOLTAGE_PIN 4
 #define  BREWING_SIM_PIN 15  // GPIO 15 for brewing simulation mode (LOW = brewing, HIGH = normal)
 
+#define USER_INACTIVITY_TIMEOUT_MS  (10UL * 60UL * 1000UL)
+#define MACHINE_INACTIVITY_TIMEOUT_MS  (10UL * 60UL * 1000UL)
+#define USER_DIM_TIMEOUT_MS  (2UL * 60UL * 1000UL)
+#define MACHINE_DIM_TIMEOUT_MS  (2UL * 60UL * 1000UL)
+#define DISPLAY_BRIGHTNESS_ACTIVE  180
+#define DISPLAY_BRIGHTNESS_DIM  30
+
 #define uS_TO_S_FACTOR 1000000ULL
 
 #endif

--- a/lib/src/LV_Helper.cpp
+++ b/lib/src/LV_Helper.cpp
@@ -8,6 +8,7 @@
  */
 #include <Arduino.h>
 #include "LV_Helper.h"
+#include "activity_monitor.h"
 
 
 #if LVGL_VERSION_MAJOR == 8
@@ -36,6 +37,7 @@ static void touchpad_read( lv_indev_drv_t *indev_driver, lv_indev_data_t *data )
     static int16_t x, y;
     uint8_t touched =   static_cast<LilyGo_Display *>(indev_driver->user_data)->getPoint(&x, &y, 1);
     if ( touched ) {
+        activity_monitor_mark_user_activity();
         data->point.x = x;
         data->point.y = y;
         data->state = LV_INDEV_STATE_PR;

--- a/src/activity_monitor.cpp
+++ b/src/activity_monitor.cpp
@@ -1,0 +1,68 @@
+#include "activity_monitor.h"
+
+namespace {
+  uint32_t user_timeout_ms = 0;
+  uint32_t machine_timeout_ms = 0;
+  unsigned long last_user_ms = 0;
+  unsigned long last_machine_ms = 0;
+  bool initialized = false;
+}
+
+void activity_monitor_init(uint32_t user_timeout, uint32_t machine_timeout)
+{
+  user_timeout_ms = user_timeout;
+  machine_timeout_ms = machine_timeout;
+  unsigned long now = millis();
+  last_user_ms = now;
+  last_machine_ms = now;
+  initialized = true;
+}
+
+void activity_monitor_mark_user_activity()
+{
+  last_user_ms = millis();
+  if (!initialized) {
+    last_machine_ms = last_user_ms;
+    initialized = true;
+  }
+}
+
+void activity_monitor_mark_machine_activity()
+{
+  last_machine_ms = millis();
+  if (!initialized) {
+    last_user_ms = last_machine_ms;
+    initialized = true;
+  }
+}
+
+static bool is_inactive(unsigned long last_ms, uint32_t timeout_ms, uint32_t now_ms)
+{
+  if (!initialized || timeout_ms == 0) {
+    return false;
+  }
+  if (now_ms < last_ms) {
+    return false;
+  }
+  return static_cast<uint32_t>(now_ms - last_ms) >= timeout_ms;
+}
+
+bool activity_monitor_is_user_inactive(uint32_t now_ms)
+{
+  return is_inactive(last_user_ms, user_timeout_ms, now_ms);
+}
+
+bool activity_monitor_is_machine_inactive(uint32_t now_ms)
+{
+  return is_inactive(last_machine_ms, machine_timeout_ms, now_ms);
+}
+
+unsigned long activity_monitor_last_user_ms()
+{
+  return last_user_ms;
+}
+
+unsigned long activity_monitor_last_machine_ms()
+{
+  return last_machine_ms;
+}

--- a/src/custom_ui_event.cpp
+++ b/src/custom_ui_event.cpp
@@ -1,10 +1,12 @@
 #include "ui/ui.h"
 #include "lamarzocco_machine.h"
+#include "activity_monitor.h"
 
 extern LaMarzoccoMachine* g_machine;
 
 void wifiSetup(lv_event_t *e)
 {
+    activity_monitor_mark_user_activity();
     lv_label_set_text(ui_SSIDLabel, "SSID: " AP_SSID);
     lv_label_set_text(ui_URLLabel, "URL:  http://" AP_SSID ".local");
     lv_scr_load(ui_setupWifiScreen);
@@ -12,6 +14,7 @@ void wifiSetup(lv_event_t *e)
 
 void turnOnMachine(lv_event_t * e)
 {
+  activity_monitor_mark_user_activity();
   // Get the machine control instance
   if (g_machine) {
     Serial.println("===========================================");
@@ -51,6 +54,7 @@ void turnOnMachine(lv_event_t * e)
 
 void toggleSteamBoiler(lv_event_t * e)
 {
+  activity_monitor_mark_user_activity();
   // Get the machine control instance
   if (g_machine) {
     Serial.println("===========================================");

--- a/src/lamarzocco_machine.cpp
+++ b/src/lamarzocco_machine.cpp
@@ -3,6 +3,7 @@
 #include "boiler_display.h"
 #include "water_alarm.h"
 #include "brewing_display.h"
+#include "activity_monitor.h"
 #include <ArduinoJson.h>
 
 LaMarzoccoMachine* LaMarzoccoMachine::_instance = nullptr;
@@ -156,6 +157,16 @@ void LaMarzoccoMachine::_websocket_message_handler(const String& message) {
                         Serial.println(no_water_alarm ? "TRUE ⚠️" : "false");
                     }
                 }
+            }
+        }
+
+        static bool last_brewing_state = false;
+        static bool last_brewing_state_valid = false;
+        if (machine_status) {
+            if (!last_brewing_state_valid || is_brewing != last_brewing_state) {
+                activity_monitor_mark_machine_activity();
+                last_brewing_state = is_brewing;
+                last_brewing_state_valid = true;
             }
         }
         
@@ -357,4 +368,3 @@ void LaMarzoccoMachine::loop() {
         }
     }
 }
-


### PR DESCRIPTION
Added further battery power optimization by turning of logging when not connected via USB
Added display dimming after period of inactivity - configurable in config.h (default is 2 minutes)
Added device going to sleep after longer period of inactivity - configurable in config.h (default is 10 minutes)
Device activity monitored is brew status change and user touch input.